### PR TITLE
Add a download url that apple silicon architecture for zoom

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3000,7 +3000,11 @@ zoomclient)
     name="zoom.us"
     type="pkg"
     packageID="us.zoom.pkg.videmeeting"
-    downloadURL="https://zoom.us/client/latest/Zoom.pkg"
+    if [[ $(arch) == i386 ]]; then
+      downloadURL="https://zoom.us/client/latest/Zoom.pkg"
+    elif [[ $(arch) == arm64 ]]; then
+      downloadURL="https://zoom.us/client/latest/Zoom.pkg?archType=arm64"
+    fi
     expectedTeamID="BJ4HAAB9B3"
     #appNewVersion=$(curl -is "https://beta2.communitypatch.com/jamf/v1/ba1efae22ae74a9eb4e915c31fef5dd2/patch/zoom.us" | grep currentVersion | tr ',' '\n' | grep currentVersion | cut -d '"' -f 4) # Does not match packageID
     blockingProcesses=( zoom.us )


### PR DESCRIPTION
copy link from https://zoom.us/download

## Test Results

### M1 macOS 11.4.0

```sh
2021-07-26 16:41:11  shifting arguments for Jamf
2021-07-26 16:41:11 zoomclient ################## Start Installomator v. 0.6.0
2021-07-26 16:41:11 zoomclient ################## zoomclient
2021-07-26 16:41:11 zoomclient BLOCKING_PROCESS_ACTION=prompt_user
2021-07-26 16:41:11 zoomclient NOTIFY=success
2021-07-26 16:41:11 zoomclient LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-07-26 16:41:11 zoomclient Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.b5H3Y3qD
2021-07-26 16:41:11 zoomclient found packageID us.zoom.pkg.videmeeting installed, version 5.7.0.446
2021-07-26 16:41:11 zoomclient appversion: 5.7.0.446
2021-07-26 16:41:11 zoomclient Latest version not specified.
2021-07-26 16:41:11 zoomclient Downloading https://zoom.us/client/latest/Zoom.pkg?archType=arm64 to zoom.us.pkg
2021-07-26 16:41:23 zoomclient no more blocking processes, continue with update
2021-07-26 16:41:23 zoomclient Installing zoom.us
2021-07-26 16:41:23 zoomclient Verifying: zoom.us.pkg
2021-07-26 16:41:23 zoomclient Team ID: BJ4HAAB9B3 (expected: BJ4HAAB9B3 )
2021-07-26 16:41:23 zoomclient Checking package version.
2021-07-26 16:41:23 zoomclient Downloaded package us.zoom.pkg.videmeeting version 
2021-07-26 16:41:23 zoomclient Installing zoom.us.pkg to /
2021-07-26 16:41:29 zoomclient Finishing…
2021-07-26 16:41:39 zoomclient found packageID us.zoom.pkg.videmeeting installed, version 5.7.0.446
2021-07-26 16:41:39 zoomclient Installed zoom.us, version 5.7.0.446
2021-07-26 16:41:39 zoomclient notifying
2021-07-26 16:41:40 zoomclient Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.b5H3Y3qD
2021-07-26 16:41:40 zoomclient App not closed, so no reopen.
2021-07-26 16:41:40 zoomclient ################## End Installomator, exit code 0 
```

URL
```sh
2021-07-26 16:41:11 zoomclient Downloading https://zoom.us/client/latest/Zoom.pkg?archType=arm64 to zoom.us.pkg
```

### Intel MacOS 10.15.7

```sh
2021-07-26 16:48:53  shifting arguments for Jamf
2021-07-26 16:48:53 zoomclient ################## Start Installomator v. 0.6.0
2021-07-26 16:48:53 zoomclient ################## zoomclient
2021-07-26 16:48:53 zoomclient BLOCKING_PROCESS_ACTION=prompt_user
2021-07-26 16:48:53 zoomclient NOTIFY=success
2021-07-26 16:48:53 zoomclient LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-07-26 16:48:53 zoomclient Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mlsvQzrG
2021-07-26 16:48:53 zoomclient found packageID us.zoom.pkg.videmeeting installed, version 5.4.59780.1220
2021-07-26 16:48:53 zoomclient appversion: 5.4.59780.1220
2021-07-26 16:48:53 zoomclient Latest version not specified.
2021-07-26 16:48:53 zoomclient Downloading https://zoom.us/client/latest/Zoom.pkg to zoom.us.pkg
2021-07-26 16:48:57 zoomclient no more blocking processes, continue with update
2021-07-26 16:48:57 zoomclient Installing zoom.us
2021-07-26 16:48:57 zoomclient Verifying: zoom.us.pkg
2021-07-26 16:48:57 zoomclient Team ID: BJ4HAAB9B3 (expected: BJ4HAAB9B3 )
2021-07-26 16:48:57 zoomclient Checking package version.
2021-07-26 16:48:57 zoomclient Downloaded package us.zoom.pkg.videmeeting version
2021-07-26 16:48:57 zoomclient Installing zoom.us.pkg to /
2021-07-26 16:49:03 zoomclient Finishing…
2021-07-26 16:49:13 zoomclient found packageID us.zoom.pkg.videmeeting installed, version 5.4.59780.1220
2021-07-26 16:49:13 zoomclient Installed zoom.us, version 5.4.59780.1220
2021-07-26 16:49:13 zoomclient notifying
2021-07-26 16:49:14 zoomclient Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mlsvQzrG
2021-07-26 16:49:14 zoomclient App not closed, so no reopen.
2021-07-26 16:49:14 zoomclient ################## End Installomator, exit code 0
```

URL
```sh
2021-07-26 16:48:53 zoomclient Downloading https://zoom.us/client/latest/Zoom.pkg to zoom.us.pkg
```